### PR TITLE
Fix account balance in summarized export

### DIFF
--- a/connector_infor_account_move/messages/move.xml.tmpl
+++ b/connector_infor_account_move/messages/move.xml.tmpl
@@ -64,7 +64,7 @@
       {% for line in JOURNAL_LINES -%}
       <JournalEntryLine sequence="{{ loop.index }}">
         <Amount currencyID="{{ line.currency_id.name or COMPANY_CURRENCY|default('', true) }}">{{ "%.5f"|format(abs(line.amount_currency or line.credit or line.debit)|default(0, true)) }}</Amount>
-        <FunctionalAmount currencyID="{{ COMPANY_CURRENCY|default('', true) }}">{{ "%.5f"|format(line.credit or line.debit|default(0, true)) }}</FunctionalAmount>
+        <FunctionalAmount currencyID="{{ COMPANY_CURRENCY|default('', true) }}">{{ "%.5f"|format(abs(line.credit or line.debit)|default(0, true)) }}</FunctionalAmount>
         <ReportingCurrencyAmount currencyID="{{ REPORTING_CURRENCY|default('', true) }}">{{ REPORTING_AMOUNT}}</ReportingCurrencyAmount>
         <GLAccount>
           <GLNominalAccount>{{ line.account_id.code|default('', true) }}</GLNominalAccount>

--- a/connector_infor_account_move/models/account_move.py
+++ b/connector_infor_account_move/models/account_move.py
@@ -250,15 +250,15 @@ class InforMoveProducer(Component):
         accounts = {}
         for line in move_lines:
             if line.account_id.id not in accounts:
-                accounts[line.account_id.id] = line.credit
+                accounts[line.account_id.id] = line.balance
             else:
-                accounts[line.account_id.id] += line.credit
+                accounts[line.account_id.id] += line.balance
         summarized_lines = []
         for account_id, amount in accounts.items():
             summarized_lines.append(
                 {'account_id': self.env['account.account'].browse(account_id),
-                 'credit': amount,
-                 'debit': 0,
+                 'credit': abs(amount) if amount < 0 else 0,
+                 'debit': abs(amount) if amount > 0 else 0,
                  'currency_id': None,
                  })
         context.update({

--- a/connector_infor_account_move/tests/examples/move_summarized.xml
+++ b/connector_infor_account_move/tests/examples/move_summarized.xml
@@ -75,8 +75,8 @@
           </UserArea>
         </JournalEntryLine>
         <JournalEntryLine sequence="2">
-          <Amount currencyID="USD">400.00000</Amount>
-          <FunctionalAmount currencyID="USD">400.00000</FunctionalAmount>
+          <Amount currencyID="USD">150.00000</Amount>
+          <FunctionalAmount currencyID="USD">150.00000</FunctionalAmount>
           <ReportingCurrencyAmount currencyID="EUR">0</ReportingCurrencyAmount>
           <GLAccount>
             <GLNominalAccount>SPR</GLNominalAccount>
@@ -89,7 +89,7 @@
             <DimensionCode sequence="2" listID="Move_Line_Ref">never to hear</DimensionCode>
             <DimensionCode sequence="3" listID="Get_default">default</DimensionCode>
           </DimensionCodes>
-          <DebitCreditFlag>C</DebitCreditFlag>
+          <DebitCreditFlag>D</DebitCreditFlag>
           <SourceAccountingDate>
             <PeriodID></PeriodID>
             <Year></Year>

--- a/connector_infor_account_move/tests/test_move_producer.py
+++ b/connector_infor_account_move/tests/test_move_producer.py
@@ -37,8 +37,8 @@ class TestMoveProducer(InforTestCase, AccountMoveMixin):
             'move_id': cls.move1.odoo_id.id,
             # number is related to move_id.name
             })
-        # Create another move
-        move = cls.env['account.move'].create({
+        # Create another move use for the summarized version
+        move3 = cls.env['account.move'].create({
             'name': 'Test move 3',
             'date': '2018-06-15',
             'journal_id': cls.journal_2.id,
@@ -48,13 +48,13 @@ class TestMoveProducer(InforTestCase, AccountMoveMixin):
                 (0, 0, {
                     'name': 'ying',
                     'debit': 50,
-                    'account_id': cls.account_2.id,
+                    'account_id': cls.account.id,
                     'ref': 'debit_line',
                     }),
                 (0, 0, {
                     'name': 'ying',
                     'debit': 100,
-                    'account_id': cls.account_2.id,
+                    'account_id': cls.account.id,
                     'ref': 'debit_line',
                     }),
                 (0, 0, {
@@ -69,7 +69,7 @@ class TestMoveProducer(InforTestCase, AccountMoveMixin):
             'backend_id': cls.backend.id,
             'name': 'test',
             'date': '2018-06-14 14:16:18',
-            'odoo_id': move.id,
+            'odoo_id': move3.id,
         })
         # Account move with foreign currency
         move_usd = cls.env['account.move'].create({


### PR DESCRIPTION
In the summarized version of the export, the move line are sorted by account. The total was only including the credit side, which was not correct.
Now the computation is done with the credit and debit side.